### PR TITLE
Upgrade to postfixadmin 3.1

### DIFF
--- a/lib/virtual.class.php
+++ b/lib/virtual.class.php
@@ -48,10 +48,9 @@ class Virtual extends VacationDriver {
         //   print_r($vacArr);
         $fwdArr = $this->virtual_alias();
 
-        $sql = sprintf("SELECT subject,body,active FROM %s.vacation WHERE email='%s'",
-                $this->cfg['dbase'], rcube::Q($this->user->data['username']));
+        $sql = sprintf("SELECT subject,body,active FROM vacation WHERE email='%s'",
+                rcube::Q($this->user->data['username']));
 
-		
         $res = $this->db->query($sql);
         if ($error = $this->db->is_error()) {
             rcube::raise_error(array('code' => 601, 'type' => 'db', 'file' => __FILE__,
@@ -64,7 +63,7 @@ class Virtual extends VacationDriver {
             $vacArr['body'] = $row['body'];
             $vacArr['subject'] = $row['subject'];
             //$vacArr['enabled'] = ($row['active'] == 1) && ($fwdArr['enabled'] == 1);
-            $vacArr['enabled'] = ($row['active'] == 1);
+            $vacArr['enabled'] = $row['active'];
         }
 
 
@@ -84,7 +83,7 @@ class Virtual extends VacationDriver {
         // Sets class property
         $this->domain_id = $this->domainLookup();
 
-        $sql = sprintf("UPDATE %s.vacation SET created=now(),active=0 WHERE email='%s'", $this->cfg['dbase'], rcube::Q($this->user->data['username']));
+        $sql = sprintf("UPDATE vacation SET created=now(),active=FALSE WHERE email='%s'", rcube::Q($this->user->data['username']));
 
 
         $this->db->query($sql);
@@ -109,20 +108,21 @@ class Virtual extends VacationDriver {
 
         // Save vacation message in any case
 
+	// LIMIT date arbitrarily put to next century (vacation.pl doesn't like NULL value)
         if (!$update) {
-            $sql = "INSERT INTO {$this->cfg['dbase']}.vacation ".
-                "( email, subject, body, cache, domain, created, active, startDate, endDate ) ".
-                "VALUES ( ?, ?, ?, '', ?, NOW(), ?, NULL, NULL )";
+            $sql = "INSERT INTO vacation ".
+                "( email, subject, body, cache, domain, created, active, activefrom, activeuntil ) ".
+                "VALUES ( ?, ?, ?, '', ?, NOW(), ?, NOW(), NOW() + interval '100 years' )";
         } else {
-            $sql = "UPDATE {$this->cfg['dbase']}.vacation SET email=?,subject=?,body=?,domain=?,active=?, startDate=NULL, endDate=NULL WHERE email=?";
+            $sql = "UPDATE vacation SET email=?,subject=?,body=?,domain=?,active=?, activefrom=NOW(), activeuntil=NOW() + interval '100 years' WHERE email=?";
         }
 
         $this->db->query($sql, 
 	    rcube::Q($this->user->data['username']), 
 	    $this->subject, 
-	    $this->body, 
+	    $this->body,
 	    $this->domain,
-	    $this->enable,
+	    $this->enable ? 'TRUE' : 'FALSE',
 	    rcube::Q($this->user->data['username']));
         if ($error = $this->db->is_error()) {
             if (strpos($error, "no such field")) {
@@ -176,9 +176,10 @@ class Virtual extends VacationDriver {
 	 * @return string SQL query with substituted parameters
     */
     private function translate($query) {
+	// vacation.pl assume that people won't use # as a valid mailbox character
         return str_replace(array('%e', '%d', '%i', '%g', '%f', '%m'),
                 array($this->user->data['username'], $this->domain, $this->domain_id,
-                    rcube::Q($this->user->data['username']) . "@" . $this->cfg['transport'], $this->forward, $this->cfg['dbase']), $query);
+                    rcube::Q(str_replace('@', '#', $this->user->data['username'])) . "@" . $this->cfg['transport'], $this->forward, $this->cfg['dbase']), $query);
     }
 
 // Sets %i. Lookup the domain_id based on the domainname. Returns the domainname if the query is empty
@@ -239,7 +240,8 @@ class Virtual extends VacationDriver {
     private function virtual_alias() {
         $forward = "";
         $enabled = false;
-        $goto = rcube::Q($this->user->data['username']) . "@" . $this->cfg['transport'];
+	// vacation.pl assume that people won't use # as a valid mailbox character
+        $goto = rcube::Q(str_replace('@', '#', $this->user->data['username'])) . "@" . $this->cfg['transport'];
 
         // Backwards compatiblity. Since >=1.6 this is no longer needed
         $sql = str_replace("='%g'", "<>''", $this->cfg['select_query']);


### PR DESCRIPTION
I'm using Postfix with Postgres since few years.
Postfixadmin is in charge of updating the DB and with last update (to 3.1), I had to change the vacation plugin on Roundcube.

Trying yours, I realize it was not compatible with my environment, so I've made few changes.

Most important are bellow :

- postgres boolean cannot be set by values 1 or 0, by default
- DB structure was different from what you expected, some field's names changed and no schema present
- vacation.pl's convention for autoreply address was making use of # character, not @

I've successfully tested my changes and maybe you want to check them before accepting this PR because it's very postgres oriented and might not work "as is" with mysql.

**WARNING:** it seems that today a new release of postfixadmin (3.2) is out and changes have been made to vacation.pl, according to the changelog. If required, I will upgrade my branch when I'll upgrade to that new version, but I don't know when.